### PR TITLE
#127 🗃️ fix : imageUrl 글자수 증가

### DIFF
--- a/src/migrations/20230102072552-create-users.js
+++ b/src/migrations/20230102072552-create-users.js
@@ -40,7 +40,7 @@ module.exports = {
         allowNull: false,
       },
       imageUrl: {
-        type: Sequelize.STRING,
+        type: Sequelize.STRING(1000),
         allowNull: true,
       },
       createdAt: {

--- a/src/models/users.js
+++ b/src/models/users.js
@@ -54,7 +54,7 @@ module.exports = (sequelize, DataTypes) => {
         allowNull: false,
       },
       imageUrl: {
-        type: DataTypes.STRING,
+        type: DataTypes.STRING(1000),
         allowNull: true,
       },
       createdAt: {


### PR DESCRIPTION
#127 🗃️ fix : imageUrl 글자수 증가

인코딩 된 값이 255자가 넘어 글자수를 증가 시켜주었습니다. 

이미지 리사이징의 의미가 없다고 생각이 들어 제거하였습니다.