### PR TITLE
#187 ✨ feat : 이메일, 휴대폰 인증 요청 추가

### DIFF
--- a/.aws/task-definition.json
+++ b/.aws/task-definition.json
@@ -147,6 +147,26 @@
         {
           "valueFrom": "arn:aws:ssm:ap-northeast-2:136644004698:parameter/app/ICON_URL",
           "name": "ICON_URL"
+        },
+        {
+          "valueFrom": "arn:aws:ssm:ap-northeast-2:136644004698:parameter/app/GATEWAY_EMAIL",
+          "name": "GATEWAY_EMAIL"
+        },
+        {
+          "valueFrom": "arn:aws:ssm:ap-northeast-2:136644004698:parameter/app/GATEWAY_PHONE",
+          "name": "GATEWAY_PHONE"
+        },
+        {
+          "valueFrom": "arn:aws:ssm:ap-northeast-2:136644004698:parameter/app/X_API_KEY_EMAIL",
+          "name": "X_API_KEY_EMAIL"
+        },
+        {
+          "valueFrom": "arn:aws:ssm:ap-northeast-2:136644004698:parameter/app/X_API_KEY_PHONE",
+          "name": "X_API_KEY_PHONE"
+        },
+        {
+          "valueFrom": "arn:aws:ssm:ap-northeast-2:136644004698:parameter/app/JWT_SECRET",
+          "name": "JWT_SECRET"
         }
       ],
       "dockerSecurityOptions": null,
@@ -177,10 +197,7 @@
   "placementConstraints": [],
   "memory": "1024",
   "taskRoleArn": "arn:aws:iam::136644004698:role/communitE",
-  "compatibilities": [
-    "EXTERNAL",
-    "EC2"
-  ],
+  "compatibilities": ["EXTERNAL", "EC2"],
   "taskDefinitionArn": "arn:aws:ecs:ap-northeast-2:136644004698:task-definition/pillnuts:1",
   "family": "pillnuts",
   "requiresAttributes": [
@@ -222,9 +239,7 @@
     }
   ],
   "pidMode": null,
-  "requiresCompatibilities": [
-    "EC2"
-  ],
+  "requiresCompatibilities": ["EC2"],
   "networkMode": null,
   "runtimePlatform": null,
   "cpu": "1024",

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+users.service.js

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,5 @@
 {
-    "singleQuote": true,
-    "semi": true,
-    "tabWidth": 2
+  "singleQuote": true,
+  "semi": true,
+  "tabWidth": 2
 }

--- a/src/architecture/controllers/users.controller.js
+++ b/src/architecture/controllers/users.controller.js
@@ -55,6 +55,42 @@ class UsersController {
     }
   };
 
+  authenticationEmail = async (req, res, next) => {
+    try {
+      const { email } = req.body;
+      const result = Joi.string().email().required().validate(email);
+
+      if (result.error) {
+        throw new ValidationError('데이터 형식이 잘못되었습니다.');
+      }
+      const code = await this.usersService.authenticationEmail(email);
+      return res.status(201).json(code);
+    } catch (error) {
+      console.log(error);
+      next(error);
+    }
+  };
+
+  authenticationPhone = async (req, res, next) => {
+    try {
+      const { phoneNumber } = req.body;
+      const result = Joi.string()
+        .length(11)
+        .pattern(/^[0-9]+$/)
+        .required()
+        .validate(phoneNumber);
+
+      if (result.error) {
+        throw new ValidationError('데이터 형식이 잘못되었습니다.');
+      }
+      const code = await this.usersService.authenticationPhone(phoneNumber);
+      return res.status(201).json(code);
+    } catch (error) {
+      console.log(error);
+      next(error);
+    }
+  };
+
   findEmail = async (req, res, next) => {
     try {
       const { phoneNumber } = req.query;

--- a/src/architecture/services/users.service.js
+++ b/src/architecture/services/users.service.js
@@ -1,5 +1,7 @@
 const UsersRepository = require('../repositories/users.repository');
 const { Users } = require('../../models/index.js');
+const axios = require('axios');
+const { createAuthToken } = require('../../util/token');
 
 const createUrl = require('../../util/presignedUrl');
 const hash = require('../../util/encryption');
@@ -48,6 +50,41 @@ class UsersService {
       throw new ExistError('중복된 이메일입니다.');
     }
   };
+
+  authenticationEmail = async (email) => {
+    const token = await createAuthToken();
+    const { data } = await axios.post(
+      process.env.GATEWAY_EMAIL,
+      {
+        email,
+      },
+      {
+        headers: {
+          'authorization_Token': `Bearer ${token}`,
+          'x-api-key': process.env.X_API_KEY_EMAIL,
+        },
+      }
+    );
+    return data;
+  };
+
+  authenticationPhone = async (phoneNumber) => {
+    const token = await createAuthToken();
+    const { data } = await axios.post(
+      process.env.GATEWAY_PHONE,
+      {
+        phoneNumber,
+      },
+      {
+        headers: {
+          'authorization_Token': `Bearer ${token}`,
+          'x-api-key': process.env.X_API_KEY_PHONE,
+        },
+      }
+    );
+    return data;
+  };
+
 
   findEmail = async (phoneNumber) => {
     const user = await this.usersRepository.findUser({

--- a/src/routes/users.route.js
+++ b/src/routes/users.route.js
@@ -8,6 +8,16 @@ const usersController = new UsersController();
 router.post('/signup', loginMiddleware, usersController.signUp);
 router.get('/signup', usersController.duplicateCheck);
 router.get('/find/email', loginMiddleware, usersController.findEmail);
+router.post(
+  '/authentication/email',
+  loginMiddleware,
+  usersController.authenticationEmail
+);
+router.post(
+  '/authentication/phone',
+  loginMiddleware,
+  usersController.authenticationPhone
+);
 router.get(
   '/find/phoneNumber',
   loginMiddleware,

--- a/src/util/token.js
+++ b/src/util/token.js
@@ -10,6 +10,10 @@ createRefreshToken = () => {
   return jwt.sign({}, process.env.SECRET_KEY, { expiresIn: '7d' });
 };
 
+createAuthToken = () => {
+  return jwt.sign({}, process.env.JWT_SECRET, { expiresIn: '1h' });
+};
+
 // Refresh Token을 검증한다.
 validateRefreshToken = (refreshtoken) => {
   try {
@@ -24,4 +28,5 @@ module.exports = {
   createAccessToken,
   createRefreshToken,
   validateRefreshToken,
+  createAuthToken,
 };


### PR DESCRIPTION
#187 ✨ feat : 이메일, 휴대폰 인증 요청 추가

프론트에서 바로 요청을 보내면 헤더에 다 노출이 되기에 프론트 - 서버 - API Gateway로 바꾸면서 좀 더 보안적으로 권한부여자를 붙여 토큰을 발급받아 같이 보내고 권한부여자 함수에서 검증을 하고 유효해야만 요청을 가게 구현하였습니다.

"가 자꾸 사라지기에 .prettierignore를 추가하여 users.service.js를 넣어 프리티어가 적용 안 되게 하였습니다. 프리티어 적용이 될 시 authorization_Token를 따옴표로 꼭 감싸주셔야합니다.



