### PR TITLE
🐛  #242 FIX: 마이페이지 리뷰 조회 수정

### DIFF
--- a/src/architecture/repositories/reviews.repository.js
+++ b/src/architecture/repositories/reviews.repository.js
@@ -88,7 +88,7 @@ class ReviewRepository {
         'report',
         'updatedAt',
       ],
-      group: ['reviewId'],
+      group: ['userId'],
       order: [['updatedAt', 'DESC']],
       offset: (page - 1) * pageSize,
       limit: Number(pageSize),

--- a/src/architecture/services/reviews.service.js
+++ b/src/architecture/services/reviews.service.js
@@ -126,11 +126,9 @@ class ReviewService {
         });
 
         let likeValue =
-          like.findIndex((l) => l.userId == loginUserId) == -1 ? false : true;
+          like.findIndex((l) => l.userId == userId) == -1 ? false : true;
         let dislikeValue =
-          dislike.findIndex((l) => l.userId == loginUserId) == -1
-            ? false
-            : true;
+          dislike.findIndex((l) => l.userId == userId) == -1 ? false : true;
 
         let report = [];
 


### PR DESCRIPTION
리뷰 조회가 되지 않는 에러.
코드상으로 기본 리뷰 조희의 loginUserId와 마이페이지 리뷰의 userId가 다른 선언값을 가진다는 것을 알지 못한 실수를 했습니다.