### PR TITLE
:bug: #245 FIX: 리뷰 좋아요순 정렬 수정

### DIFF
--- a/src/architecture/repositories/reviews.repository.js
+++ b/src/architecture/repositories/reviews.repository.js
@@ -12,11 +12,20 @@ class ReviewRepository {
     return Reviews.findAndCountAll({
       raw: true,
       where: data,
-      include: {
-        model: Users,
-        attributes: ['nickname', 'imageUrl'],
-        required: true,
-      },
+      include: [
+        {
+          model: Users,
+          attributes: ['nickname', 'imageUrl'],
+          required: true,
+        },
+        {
+          model: Likes,
+          as: 'Likes',
+          attributes: [],
+          duplicating: false,
+          required: false,
+        },
+      ],
       attributes: [
         'reviewId',
         'userId',
@@ -24,6 +33,10 @@ class ReviewRepository {
         'review',
         'report',
         'updatedAt',
+        [
+          Likes.sequelize.fn('count', Likes.sequelize.col('Likes.reviewId')),
+          'likeCount',
+        ],
       ],
       group: ['reviewId'],
       order: order,


### PR DESCRIPTION
#245 FIX: 리뷰 좋아요순 정렬 수정

DB에서 count로 체크 후 정렬 하여야 하는 부분을 삭제하여 좋아요 순서로 정렬이 안되었음.
해당 부분 다시 추가 수정함.