### PR TITLE
#251 🐛 fix : 마이리뷰조회 페이지네이션 수정

### DIFF
--- a/src/architecture/repositories/reviews.repository.js
+++ b/src/architecture/repositories/reviews.repository.js
@@ -101,7 +101,7 @@ class ReviewRepository {
         'report',
         'updatedAt',
       ],
-      group: ['userId'],
+      group: ['reviewId'],
       order: [['updatedAt', 'DESC']],
       offset: (page - 1) * pageSize,
       limit: Number(pageSize),


### PR DESCRIPTION
#251  🐛 fix : 마이리뷰조회 페이지네이션 수정

group이 userId로 묶여있어서 하나만 조회되는 버그가 있어 reviewId로 수정하였습니다.