### PR TITLE
#263 🐛 fix : 회원가입 로직 수정

### DIFF
--- a/src/architecture/controllers/users.controller.js
+++ b/src/architecture/controllers/users.controller.js
@@ -3,6 +3,7 @@ const Joi = require('joi');
 
 const {
   ValidationError,
+  AuthenticationError,
 } = require('../../middlewares/exceptions/error.class.js');
 
 class UsersController {
@@ -22,15 +23,19 @@ class UsersController {
           .required()
           .pattern(new RegExp(/^(?=.*[A-Za-z])(?=.*[0-9]).{8,15}$/)),
         confirm: Joi.string().required().valid(Joi.ref('password')),
+        certification: Joi.boolean().required(),
       });
 
       const result = schema.validate(req.body);
-
       if (result.error) {
         throw new ValidationError('데이터 형식이 잘못되었습니다.');
       }
 
-      const { email, password, nickname, phoneNumber } = req.body;
+      const { email, password, nickname, phoneNumber, certification } =
+        req.body;
+      if (!certification) {
+        throw new AuthenticationError('휴대폰 인증이 필요합니다');
+      }
       await this.usersService.signUp(email, password, nickname, phoneNumber);
       return res.status(201).json({ message: '회원가입에 성공하였습니다' });
     } catch (error) {

--- a/src/architecture/services/users.service.js
+++ b/src/architecture/services/users.service.js
@@ -2,6 +2,7 @@ const UsersRepository = require('../repositories/users.repository');
 const { Users } = require('../../models/index.js');
 const axios = require('axios');
 const { createAuthToken } = require('../../util/token');
+const { Op } = require('sequelize');
 
 const createUrl = require('../../util/presignedUrl');
 const hash = require('../../util/encryption');
@@ -21,10 +22,10 @@ class UsersService {
   signUp = async (email, password, nickname, phoneNumber) => {
     const user = await this.usersRepository.findUser({
       raw: true,
-      where: { email, loginType: 'Local' },
+      where: {[Op.or] : [ {email}, {phoneNumber}], loginType: 'Local' },
     });
     if (user) {
-      throw new ExistError('중복된 이메일입니다.');
+      throw new ExistError('중복된 유저가 존재합니다.');
     }
     password = hash(password);
 


### PR DESCRIPTION
#263 🐛 fix : 회원가입 로직 수정

회원가입 로직 변경하였습니다.

certification를 바디값에 추가하여 휴대폰 인증 했을 때 true, false 값을 받기로 했으며 true여야만 통과되게끔 구현하였습니다.

+ 이메일, 휴대폰이 중복일 경우 중복된 유저라고 에러를 돌려줍니다.