### PR TITLE
:bug: #262 FIX : 리뷰 조회시 순서 정렬 createdAt으로 변경

### DIFF
--- a/src/architecture/repositories/reviews.repository.js
+++ b/src/architecture/repositories/reviews.repository.js
@@ -99,10 +99,10 @@ class ReviewRepository {
         'medicineId',
         'review',
         'report',
-        'updatedAt',
+        'createdAt',
       ],
       group: ['reviewId'],
-      order: [['updatedAt', 'DESC']],
+      order: [['createdAt', 'DESC']],
       offset: (page - 1) * pageSize,
       limit: Number(pageSize),
     });

--- a/src/architecture/repositories/reviews.repository.js
+++ b/src/architecture/repositories/reviews.repository.js
@@ -32,7 +32,7 @@ class ReviewRepository {
         'medicineId',
         'review',
         'report',
-        'updatedAt',
+        'createdAt',
         [
           Likes.sequelize.fn('count', Likes.sequelize.col('Likes.reviewId')),
           'likeCount',

--- a/src/architecture/services/reviews.service.js
+++ b/src/architecture/services/reviews.service.js
@@ -20,8 +20,8 @@ class ReviewService {
     if (!tag) {
       data = { medicineId };
     }
-    if (order === 'updatedAt') {
-      order = [['updatedAt', 'DESC']];
+    if (order === 'createdAt') {
+      order = [['createdAt', 'DESC']];
     } else if (order === 'likeCount') {
       order = [['likeCount', 'DESC']];
     }


### PR DESCRIPTION
1. 리뷰를 신고 했을경우, 신고한 리뷰가 update 되어서 리뷰 조회 시 신고 당한 리뷰가 맨 위로 정렬이 되는 버그가 있었습니다.

2. 리뷰를 수정한 후에도 맨 처음 썼던 리뷰의 날짜(createdAt으로 정렬)가 보여져야 하는게 맞다고 판단되어, 리뷰 조회 시 updatedAt 정렬을 createdAt으로 정렬하는 것으로 변경하였습니다.